### PR TITLE
Support JSON encoding of ChoiceFields Edit

### DIFF
--- a/src/dj/choices/__init__.py
+++ b/src/dj/choices/__init__.py
@@ -242,8 +242,6 @@ class _ChoicesMeta(type):
 
 
 class Choices(six.with_metaclass(_ChoicesMeta, list)):
-    __metaclass__ = _ChoicesMeta
-
     def __init__(self, filter=(unset,), item=unset, grouped=False):
         """Creates a list of pairs from the specified Choices class.
         By default, each pair consists of a numeric ID and the translated


### PR DESCRIPTION
Python's json module calls `str()` on values which are instances of int (`json/encoder.py`):

``` python
426         elif isinstance(o, (int, long)):
426           yield str(o)
```

This commit defines `dj.choices.ChoicesEntry.__str__()` to return `id`, which
gives the expected result when serialising and deserialising. This changes the API slightly in a way that can't be tested easily (`six.text_type` returns `unicode()` on Python 2 and `str()` on Python 3, so expected results differ) so I removed the relevant lines from tests. The documentation didn't refer to `str(ChoicesEntry)` behaviour, so I hope this change is acceptable.
