### PR TITLE
Fix ChoiceField's metaclass on Python 3

### DIFF
--- a/src/dj/choices/fields.py
+++ b/src/dj/choices/fields.py
@@ -39,9 +39,8 @@ from dj.choices import unset, Choices, Gender
 import six
 
 
-class ChoiceField(IntegerField):
+class ChoiceField(six.with_metaclass(models.SubfieldBase, IntegerField)):
     description = _("Integer")
-    __metaclass__ = models.SubfieldBase
 
     def __init__(self, *args, **kwargs):
         if kwargs.get('_in_south'): # workaround for South removing `choices`

--- a/src/dj/choices/tests.py
+++ b/src/dj/choices/tests.py
@@ -242,6 +242,8 @@ class SimpleTest(TestCase):
         judy.sport = Sports.mountaineering
         judy.save()
         judy2 = Favourites.objects.get(name='Judy')
+        # Check the type to make sure field's to_python is getting called
+        self.assertEqual(type(judy2.color), type(Color.blue))
         self.assertEqual(judy2.color, Color.blue)
         self.assertEqual(judy2.music, MusicGenre.rock)
         self.assertEqual(judy2.sport, Sports.mountaineering)


### PR DESCRIPTION
Without this ChoiceField's to_python is not called, and that makes objects retrieved from database have ints as ChoiceField values.