### PR TITLE
Django 1.11+ compatibility for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.tox/
+/build/
+/src/log/
+/dist/
+/src/dj.choices.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 
-before_install:
-  - pip install tox
+install: pip install tox-travis
+
+python:
+  - "2.7"
+  - "3.7"
 
 script: tox

--- a/src/dj/_choicestestproject/urls.py
+++ b/src/dj/_choicestestproject/urls.py
@@ -1,17 +1,3 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import include, url
 
-# Uncomment the next two lines to enable the admin:
-# from django.contrib import admin
-# admin.autodiscover()
-
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', '_choicestestproject.views.home', name='home'),
-    # url(r'^_choicestestproject/', include('_choicestestproject.foo.urls')),
-
-    # Uncomment the admin/doc line below to enable admin documentation:
-    # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
-    # Uncomment the next line to enable the admin:
-    # url(r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = []

--- a/src/dj/choices/__init__.py
+++ b/src/dj/choices/__init__.py
@@ -242,8 +242,6 @@ class _ChoicesMeta(type):
 
 
 class Choices(six.with_metaclass(_ChoicesMeta, list)):
-    __metaclass__ = _ChoicesMeta
-
     def __init__(self, filter=(unset,), item=unset, grouped=False):
         """Creates a list of pairs from the specified Choices class.
         By default, each pair consists of a numeric ID and the translated

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,14 @@
 [tox]
 envlist =
-    {py27,py34,py35}-django{18,19,110},
-    {py27,py34}-django{16,17},
-    {py27}-django{14,15},
+    py37-django20,
+    {py27,py37}-django111,
 
 [testenv]
 commands =
-  {envbindir}/django-admin.py test
+  {envbindir}/django-admin.py test --pythonpath=src/dj/
 setenv =
   DJANGO_SETTINGS_MODULE=dj._choicestestproject.settings
 deps =
-    django14: Django==1.4.22
-    django15: Django==1.5.12
-    django16: Django==1.6.11
-    django17: Django==1.7.11
-    django18: Django==1.8.15
-    django19: Django==1.9.10
-    django110: Django==1.10.2
+    django110: Django==1.10.8
+    django111: Django==1.11.26
+    django20: Django==2.0.13


### PR DESCRIPTION
Get tests passing on Django 1.11 and 2.0

(Also includes #20 because otherwise tests still wouldn't work)