### PR TITLE
Release version 0.12.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -327,6 +327,11 @@ The easiest way would be to run::
 Change Log
 ----------
 
+0.12.0
+~~~~~~
+
+* Add support for Django 1.11 - 2.2
+
 0.11.0
 ~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'rb') as ldf:
 
 setup (
     name = 'dj.choices',
-    version = '0.11.0',
+    version = '0.12.0',
     author = '\xc5\x81ukasz Langa',
     author_email = 'lukasz@langa.pl',
     description = "An enum implementation for Django forms and models.",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py37-django20,
-    {py27,py37}-django111,
+    py37-django{200,202},
+    {py27,py37}-django{110,111},
 
 [testenv]
 commands =
@@ -11,4 +11,5 @@ setenv =
 deps =
     django110: Django==1.10.8
     django111: Django==1.11.26
-    django20: Django==2.0.13
+    django200: Django==2.0.13
+    django202: Django==2.2.7


### PR DESCRIPTION
Re #17

It'd be nice to get a release that's compatible with current Django up on PyPI 👍

I thought I saw 0.12.0 kicking around somewhere already, but maybe I dreamed it – `setup.py` was at `0.11.0`.